### PR TITLE
Expose the validate authority setting from the underlying MSAL

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ Find the assignment for ClientID and replace the value with the Application ID f
         authority: 'https://login.microsoftonline.com/tfp/<your-tenant-name>.onmicrosoft.com/<your-sign-in-sign-up-policy>',
         redirectUri: '<Optional redirect URI for your application>',
         type: LoginType.Popup,
-        persistLoginPastSession: true
+        persistLoginPastSession: true,
+        validateAuthority: true
       })}
       unauthenticatedFunction={this.loginCallback}
       authenticatedFunction={this.logoutCallback}
@@ -91,6 +92,7 @@ As of right now, there is only a single provider, but more may be added in futur
 | `redirectUri` | **[Optional]** String representing the URI to redirect back to when authentication completes |
 | `type` | **[Optional]** `LoginType.Popup` or `LoginType.Redirect`. Redirect is the default if this value is not provided. Make sure to import `LoginType` from the react-aad-msal npm module if using this property  |
 |`persistLoginPastSession`|**[Optional]** A boolean value representing if you want your user to be authenticated after the session ends. If `true` login information will be cached in `LocalStorage`. If `false` login information will be cached in `SessionStorage`. Defaults to `false`.|
+|`validateAuthority` | **[Optional]** A boolean value to determine if the authority is validated against a known list of authorities. Defaults to `true`.|
 
 ## Login
 To login, first create a callback function for the AzureAD component to consume.  This function will be called when the component loads, and it will pass in the function to be called when the user wants to login.  In this case, we create a button that will log the user in.

--- a/src/Interfaces.ts
+++ b/src/Interfaces.ts
@@ -47,12 +47,13 @@ interface IMsalAuthProviderConfig {
   persistLoginPastSession?: boolean,
   scopes: string[],
   type?: LoginType,
-  redirectUri?: string
+  redirectUri?: string,
+  validateAuthority: boolean
 }
 
 interface IAuthProvider {
   userInfoChangedCallback? : (userInfo: IUserInfo) => void,
-  
+
   getUserInfo() : IUserInfo,
   login() : void,
   logout() : void,

--- a/src/MsalAuthProvider.ts
+++ b/src/MsalAuthProvider.ts
@@ -50,7 +50,8 @@ export abstract class MsalAuthProvider implements IAuthProvider {
       this.tokenRedirectCallback,
       {
         cacheLocation: authProviderConfig.persistLoginPastSession ? StorageLocations.localStorage : StorageLocations.sessionStorage,
-        redirectUri: authProviderConfig.redirectUri
+        redirectUri: authProviderConfig.redirectUri,
+        validateAuthority: authProviderConfig.validateAuthority == undefined ? true : authProviderConfig.validateAuthority
       }
     );
   }
@@ -68,7 +69,7 @@ export abstract class MsalAuthProvider implements IAuthProvider {
   protected tokenRedirectCallback(errorDesc: string, idToken: string, error: string, tokenType: string) : void {
     // Empty callback by default
   }
-  
+
   protected checkIfUserAuthenticated = () => {
     if (this.isLoggedIn()) {
       const idToken = this.getCacheItem(this.clientApplication.cacheLocation, IDTokenKey);
@@ -103,7 +104,7 @@ export abstract class MsalAuthProvider implements IAuthProvider {
       this.userInfoChangedCallback(user);
     }
   }
-  
+
   // a person is logged in if UserAgentApplication has a current user, if there is an idtoken in the cache, and if the token in the cache is not expired
   private isLoggedIn = () => {
     const potentialLoggedInUser = this.clientApplication.getUser();


### PR DESCRIPTION
## Purpose

There is currently an issue in the underlying MSAL library which prevents logins using the new `b2clogin.com` url (https://github.com/AzureAD/microsoft-authentication-library-for-js/issues/435). It can be worked around by turning off validation. This is somewhat undesirable so the flag defaults to true which will maintain validation.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
New config setting


```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
Create a new tenant that uses the new b2clogin.com domain for policies. Try to authenticate against it. Authentication will fail to open an window with the error 

```
[ERROR] Login popup failed; endpoints_resolution_error:Endpoints cannot be resolved
```

Set validate authority to false and test again. It should now work.

## What to Check
Verify that a b2clogin.com domain works when set as the authority

https://test.b2clogin.com/tfp/justiceformetest.onmicrosoft.com/B2C_1_SiUpIn
```
<AzureAD
                provider={new MsalAuthProviderFactory({
                    authority: 'https://test.b2clogin.com/tfp/justiceformetest.onmicrosoft.com/B2C_1_SiUpIn',
                    clientID: 'aaaaaeb2-ea26-4271-a138-f69e77777b9f',
                    scopes: ["https://test.onmicrosoft.com/API/access"],
                    type: LoginType.Popup,
                    persistLoginPastSession: true,
                    validateAuthority: false
                })}
                unauthenticatedFunction={this.unauthenticatedFunction}
                authenticatedFunction={this.authenticatedFunction}
                userInfoCallback={this.userJustLoggedIn} />
```

## Other Information

This may not be needed once MSAL has been updated but it is likely that if future domains are added then MSAL will again lag behind and this setting will be useful once more.