### PR TITLE
Fix edge case where AzureAD render() function can return void

### DIFF
--- a/sample/src/SampleAppRedirectOnLaunch.js
+++ b/sample/src/SampleAppRedirectOnLaunch.js
@@ -31,11 +31,11 @@ class SampleAppRedirectOnLaunch extends React.Component {
     super(props);
 
     this.interval = null;
-    let redirectEnabled = sessionStorage.getItem("redirectEnabled") || false;
+    let redirectEnabled = sessionStorage.getItem('redirectEnabled') || false;
     this.state = {
       counter: 5,
-      redirectEnabled: redirectEnabled
-    }
+      redirectEnabled: redirectEnabled,
+    };
   }
 
   handleCheck = () => {
@@ -43,12 +43,13 @@ class SampleAppRedirectOnLaunch extends React.Component {
       if (!this.state.redirectEnabled) {
         this.clearRedirectInterval();
       } else {
-        sessionStorage.setItem("redirectEnabled", true);
+        sessionStorage.setItem('redirectEnabled', true);
       }
     });
-  }
+  };
 
   unauthenticatedFunction = loginFunction => {
+    console.log('UNAUTHENTICATED');
     if (this.state.redirectEnabled && !this.interval) {
       this.interval = setInterval(() => {
         if (this.state.counter > 0) {
@@ -60,50 +61,68 @@ class SampleAppRedirectOnLaunch extends React.Component {
         }
       }, 1000);
     }
-    
+
     if (this.state.redirectEnabled) {
-      return (<div>Redirecting in {this.state.counter} seconds...</div>);
+      return <div>Redirecting in {this.state.counter} seconds...</div>;
     }
-    
-    return (<div />);
+
+    return <div />;
   };
 
   clearRedirectInterval() {
     clearInterval(this.interval);
     this.setState({ counter: 5 });
-    sessionStorage.removeItem("redirectEnabled");
+    sessionStorage.removeItem('redirectEnabled');
     this.interval = null;
   }
 
   userJustLoggedIn = receivedUserInfo => {
+    console.log('USER JUST LOGGED IN');
+    console.log(receivedUserInfo);
     this.props.userInfoCallback(receivedUserInfo);
-  }
+  };
 
   authenticatedFunction = logout => {
-    return (<div><button onClick={() => {
-      logout();
-    }} className="Button">Logout</button></div>);
-  }
+    console.log('AUTHENTICATED');
+    return (
+      <div>
+        <button
+          onClick={() => {
+            logout();
+          }}
+          className="Button"
+        >
+          Logout
+        </button>
+      </div>
+    );
+  };
 
   render() {
     return (
       <div>
-        {!this.props.userInfo?
+        {!this.props.userInfo ? (
           <div>
             <input type="checkbox" value={this.state.redirectEnabled} onChange={this.handleCheck} /> Enable redirect
-          </div> : <div/>}
+          </div>
+        ) : (
+          <div />
+        )}
         <AzureAD
-          provider={new MsalAuthProviderFactory({
-            authority: process.env.REACT_APP_AUTHORITY,
-            clientID: process.env.REACT_APP_AAD_APP_CLIENT_ID,
-            scopes: ["openid"],
-            type: LoginType.Redirect,
-            persistLoginPastSession: true,
-            postLogoutRedirectUri: window.origin.location
-          })}
+          provider={
+            new MsalAuthProviderFactory({
+              authority: process.env.REACT_APP_AUTHORITY,
+              clientID: process.env.REACT_APP_AAD_APP_CLIENT_ID,
+              scopes: ['openid'],
+              type: LoginType.Redirect,
+              persistLoginPastSession: true,
+              postLogoutRedirectUri: window.origin.location,
+            })
+          }
           unauthenticatedFunction={this.unauthenticatedFunction}
           userInfoCallback={this.userJustLoggedIn}
-          authenticatedFunction={this.authenticatedFunction} />
+          authenticatedFunction={this.authenticatedFunction}
+        />
       </div>
     );
   }

--- a/src/AzureAD.tsx
+++ b/src/AzureAD.tsx
@@ -64,14 +64,14 @@ class AzureAD extends React.Component<IProps, IState> {
     switch (this.state.authenticationState) {
       case AuthenticationState.Authenticated:
         if (this.props.authenticatedFunction) {
-          return this.props.authenticatedFunction(this.logout);
+          return this.props.authenticatedFunction(this.logout) || null;
         }
         else {
-          return this.props.children;
+          return this.props.children || null;
         }
       case AuthenticationState.Unauthenticated:
         if (this.props.unauthenticatedFunction) {
-          return this.props.unauthenticatedFunction(this.login);
+          return this.props.unauthenticatedFunction(this.login) || null;
         } else {
           return null;
         }

--- a/src/AzureAD.tsx
+++ b/src/AzureAD.tsx
@@ -38,9 +38,9 @@ type LogoutFunction = () => void;
 
 interface IProps {
   provider: IAuthProviderFactory,
-  unauthenticatedFunction: UnauthenticatedFunction,
-  authenticatedFunction: AuthenticatedFunction,
-  userInfoCallback: UserInfoCallback,
+  unauthenticatedFunction?: UnauthenticatedFunction,
+  authenticatedFunction?: AuthenticatedFunction,
+  userInfoCallback?: UserInfoCallback,
   reduxStore?: Store
 }
 
@@ -94,8 +94,10 @@ class AzureAD extends React.Component<IProps, IState> {
     });
 
     if (user) {
-      this.props.userInfoCallback(user);
       this.dispatchToProvidedReduxStore(user);
+      if (this.props.userInfoCallback) {
+        this.props.userInfoCallback(user);
+      }
     }
   }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -25,8 +25,8 @@
 
 import { AAD_LOGIN_SUCCESS, AAD_LOGOUT_SUCCESS } from './actions';
 import { AzureAD } from './AzureAD'
-import { AuthenticationState, LoginType } from './Interfaces';
+import { AuthenticationState, IUserInfo, LoginType } from './Interfaces';
 import { MsalAuthProviderFactory } from './MsalAuthProviderFactory';
 
-export { AzureAD, AAD_LOGIN_SUCCESS, AAD_LOGOUT_SUCCESS, AuthenticationState, LoginType, MsalAuthProviderFactory };
+export { AzureAD, AAD_LOGIN_SUCCESS, AAD_LOGOUT_SUCCESS, AuthenticationState, IUserInfo, LoginType, MsalAuthProviderFactory };
 export default AzureAD;


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* In the scenario where `authenticatedFunction` or `unauthenticatedFunction` don't return a value, React will throw errors because their output is returned from the `render()` function, and render should return either an element or null.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Setup an unauthenticatedFunction callback which does not return any value, and view the console output when opening the app in the unauthenticated state.

## Other Information
The edge case described here does not break anything, just emits errors to the console.