### PR TITLE
Call redux store first and then change state

### DIFF
--- a/src/AzureAD.tsx
+++ b/src/AzureAD.tsx
@@ -99,13 +99,13 @@ class AzureAD extends React.Component<IProps, IState> {
     }
     this.setState({
       authenticationState: state
+    },
+    ()=> {
+      if (user && this.props.accountInfoCallback) {
+          this.props.accountInfoCallback(user);
+      }
     });
 
-    if (user) {
-      if (this.props.accountInfoCallback) {
-        this.props.accountInfoCallback(user);
-      }
-    }
   }
 
   private login = () => {

--- a/src/AzureAD.tsx
+++ b/src/AzureAD.tsx
@@ -94,12 +94,14 @@ class AzureAD extends React.Component<IProps, IState> {
   }
 
   public updateAuthenticationState = (state: AuthenticationState, user?: IAccountInfo) => {
+    if (user) {
+      this.dispatchToProvidedReduxStore(user);
+    }
     this.setState({
       authenticationState: state
     });
 
     if (user) {
-      this.dispatchToProvidedReduxStore(user);
       if (this.props.accountInfoCallback) {
         this.props.accountInfoCallback(user);
       }


### PR DESCRIPTION
## Purpose
The idea here is that after the authentication state is changed from the AuthProvider first to call the dispatching function to update the store and then changing the internal state of the component.
Why: Because if you first change the state and the authentication was successfully we call the authenticatedFunction which will show the components (in my case containers).
If they call some services and these services require the token from the store then the requests to load the resources will fail.

See the image diagrams below:
https://drive.google.com/open?id=1VsbILnFlhMntvnPfWukgAExS2E_xQ7mP
https://drive.google.com/open?id=1kfL5RR02xTMqVPXp648x8jJcVquGG90O

## Does this introduce a breaking change?
No
```
[ ] Yes
[[X]](url) No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[?] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[X] Refactoring (no functional changes, no api changes)
[X] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->