### PR TITLE
Wrong enum type for redirect in sample

### DIFF
--- a/sample/src/SampleAppRedirectOnLaunch.js
+++ b/sample/src/SampleAppRedirectOnLaunch.js
@@ -126,7 +126,7 @@ class SampleAppRedirectOnLaunch extends React.Component {
               {
                 scopes: ['openid'],
               },
-              LoginType.Popup,
+              LoginType.Redirect,
             )
           }
           unauthenticatedFunction={this.unauthenticatedFunction}


### PR DESCRIPTION
## Purpose
When I pulled this down, the sample app didn't work for the redirect example

## Does this introduce a breaking change?
No

## Pull Request Type
Bugfix

## How to Test
Manually tested

## What to Check
Check the sample app works for redirect example
