### PR TITLE
Fix Redirection after login not storing token

### DIFF
--- a/src/AzureAD.tsx
+++ b/src/AzureAD.tsx
@@ -58,9 +58,13 @@ class AzureAD extends React.Component<IProps, IState> {
     this.authProvider = this.props.provider.getAuthProvider();
     this.authProvider.onAuthenticationStateChanged = this.updateAuthenticationState;
 
-    this.state = { authenticationState: this.authProvider.authenticationState }
+    const authState = this.authProvider.authenticationState;
+    this.state = { authenticationState: authState };
 
-    if (this.props.forceLogin && this.state.authenticationState === AuthenticationState.Unauthenticated) {
+    if (authState === AuthenticationState.Authenticated) {
+      const account = this.authProvider.getAccountInfo();
+      this.updateAuthenticationState(authState, account);
+    } else if (this.state.authenticationState === AuthenticationState.Unauthenticated && this.props.forceLogin) {
       this.login();
     }
   }
@@ -87,25 +91,21 @@ class AzureAD extends React.Component<IProps, IState> {
     }
   }
 
-  public resetAccountInfo = () => {
-    if (this.props.reduxStore) {
-      this.props.reduxStore.dispatch(logoutSuccessful());
+  public updateAuthenticationState = (newState: AuthenticationState, account?: IAccountInfo) => {
+    if (account) {
+      this.dispatchAccountInfo(account);
     }
-  }
-
-  public updateAuthenticationState = (state: AuthenticationState, user?: IAccountInfo) => {
-    if (user) {
-      this.dispatchToProvidedReduxStore(user);
+    
+    if (newState !== this.state.authenticationState) {
+      this.setState({
+        authenticationState: newState
+      },
+      ()=> {
+        this.handleAccountInfoCallback(account);
+      });
+    } else {
+      this.handleAccountInfoCallback(account);
     }
-    this.setState({
-      authenticationState: state
-    },
-    ()=> {
-      if (user && this.props.accountInfoCallback) {
-          this.props.accountInfoCallback(user);
-      }
-    });
-
   }
 
   private login = () => {
@@ -117,13 +117,25 @@ class AzureAD extends React.Component<IProps, IState> {
       return;
     }
 
-    this.resetAccountInfo();
+    this.dispatchLogout();
     this.authProvider.logout();
   };
 
-  private dispatchToProvidedReduxStore(data: IAccountInfo) {
+  private dispatchLogout = () => {
+    if (this.props.reduxStore) {
+      this.props.reduxStore.dispatch(logoutSuccessful());
+    }
+  }
+
+  private dispatchAccountInfo = (data: IAccountInfo) => {
     if (this.props.reduxStore) {
       this.props.reduxStore.dispatch(loginSuccessful(data))
+    }
+  }
+
+  private handleAccountInfoCallback = (account?: IAccountInfo)  => {
+    if (account && this.props.accountInfoCallback) {
+      this.props.accountInfoCallback(account);
     }
   }
 }

--- a/src/MsalRedirectAuthProvider.ts
+++ b/src/MsalRedirectAuthProvider.ts
@@ -24,15 +24,20 @@
 //
 
 import { AuthenticationParameters, AuthError, AuthResponse, Configuration } from 'msal';
+import { Logger } from './logger';
 import { MsalAuthProvider } from './MsalAuthProvider';
 
 export class MsalRedirectAuthProvider extends MsalAuthProvider {
   constructor(authProviderConfig: Configuration, authParameters: AuthenticationParameters) {
     super(authProviderConfig, authParameters);
 
-    // tslint:disable-next-line: no-empty
     const authRedirectCallback = (error: AuthError, response: AuthResponse) => {
-      // Empty callback by default
+      if (error) {
+        Logger.error(`Login redirect failed; ${error}`);
+        return;
+      } else {
+        this.acquireTokens(response.idToken.rawIdToken);
+      }
     };
 
     this.UserAgentApplication.handleRedirectCallback(authRedirectCallback);


### PR DESCRIPTION
Fix issues described in #102 where Redirection auth is not properly setting the token, and not storing in Redux until page refresh.

## Purpose
Fixes a couple issues described in issue #102.

- When redirected back from logging in, the Redux state is not correctly populated until a page refresh occurs. This was disguised by the fact that in most circumstances, MSAL initiates a page refresh after being redirected back. Without the refresh, this issue occurs because on page load the `MsalAuthProvider` is instantiated so that an instance can be passed to the `AzureAD` component. In the provider's constructor, it instantiates an instance of the `UserAgentApplication` immediately and synchronously this finds the `idToken` in the hash and authenticates the user. It then will call the `onAuthenticationStateChanged` callback and pass it the user's details. However, this callback has never been set since it is the responsibility of the `AzureAD` component, which has not loaded yet. THerefore the updated user and auth state are lost. Solution is to put an additional check in the `AzureAD` constructor to verify if the user is authenticated, then dispatch the account details to Redux.
- When the `UserAgentApplication` executes the `handleRedirectCallback()` function, a new token is never acquired seamlessly. Instead, the user would have had to perform a page refresh for the proper acquire method to execute.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code
* Set the `navigateToLoginRequestUrl` config to `false`. This prevents MSAL from performing a refresh which would hide this issue.
* Test the Redirect workflow. Verify that the account details did not make it into Redux using the React DevTools extension.

```
git clone [repo-address]
cd [repo-name]
git checkout andcra/set-redirect-token
npm run start-dev
```