### PR TITLE
Fix spelling mistake in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ A common pattern to lock down an entire application with forced authentication i
 
 ### Higher-Order Component
 
-Sometimes it's easier to utilize a Higher-Order Component (HOC) to lock down an app with authentiction. This can be accomplished with the `withAuthentication` component.
+Sometimes it's easier to utilize a Higher-Order Component (HOC) to lock down an app with authentication. This can be accomplished with the `withAuthentication` component.
 
 ```Typescript
 // ...


### PR DESCRIPTION
## Purpose
Fixes a misspelled word in the the README.md text.