### PR TITLE
Fix bug where UserAgentApplication is not being exposed properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,8 @@ const sampleReducer = (state = initialState, action) => {
 While this wrapper attempts to provide a full-featured means of authenticating with Azure AD using the MSAL library, for advanced cases you may want to accesst the underlying `UserAgentApplication` object which is the entrypoint for all MSAL functionality. As an escape hatch, the auth provider returned with `MsalAuthProviderFactory` exposes the `UserAgentApplication` as a public member.
 
 ```jsx
-const authProvider = new MsalAuthProviderFactory({...})
+const authProviderFactory = new MsalAuthProviderFactory(config, authenticationParameters)
+const authProvider = authProviderFactory.getAuthProvider();
 // authProvider.UserAgentApplication provides access to MSAL features
 
 <AzureAD

--- a/sample/package-lock.json
+++ b/sample/package-lock.json
@@ -10103,7 +10103,7 @@
       "version": "file:..",
       "requires": {
         "dotenv": "4.0.0",
-        "msal": "1.0.1",
+        "msal": "1.1.1",
         "promise": "8.0.1",
         "react": "16.3.2",
         "redux": "4.0.1"

--- a/src/AzureAD.tsx
+++ b/src/AzureAD.tsx
@@ -27,8 +27,8 @@ import * as React from 'react';
 import { Store } from 'redux';
 
 import { loginSuccessful, logoutSuccessful } from './actions';
-import { AccountInfoCallback, AuthenticationState, IAccountInfo, IAuthProvider, IAuthProviderFactory } from './Interfaces';
-
+import { AccountInfoCallback, AuthenticationState, IAccountInfo, IAuthProviderFactory } from './Interfaces';
+import { MsalAuthProvider } from './MsalAuthProvider';
 
 
 type UnauthenticatedFunction = (login: LoginFunction) => JSX.Element;
@@ -50,7 +50,7 @@ interface IState {
 }
 
 class AzureAD extends React.Component<IAzureADProps, IState> {
-  private authProvider: IAuthProvider;
+  private authProvider: MsalAuthProvider;
 
   constructor(props: IAzureADProps) {
     super(props);

--- a/src/Interfaces.ts
+++ b/src/Interfaces.ts
@@ -23,6 +23,7 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 import { Account, AuthResponse } from 'msal';
+import { MsalAuthProvider } from './MsalAuthProvider';
 
 export type AccountInfoCallback = (token: IAccountInfo) => void;
 
@@ -45,7 +46,7 @@ export interface IAccountInfo {
 }
 
 export interface IAuthProviderFactory {
-  getAuthProvider(): IAuthProvider;
+  getAuthProvider(): MsalAuthProvider;
 }
 
 export interface IAuthProvider {

--- a/src/MsalAuthProviderFactory.ts
+++ b/src/MsalAuthProviderFactory.ts
@@ -23,7 +23,8 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 import { AuthenticationParameters, Configuration } from 'msal';
-import { IAuthProvider, IAuthProviderFactory, LoginType } from './Interfaces';
+import { IAuthProviderFactory, LoginType } from './Interfaces';
+import { MsalAuthProvider } from './MsalAuthProvider';
 import { MsalPopupAuthProvider } from './MsalPopupAuthProvider';
 import { MsalRedirectAuthProvider } from './MsalRedirectAuthProvider';
 
@@ -31,18 +32,21 @@ export class MsalAuthProviderFactory implements IAuthProviderFactory {
   private config: Configuration;
   private authParameters: AuthenticationParameters;
   private type: LoginType;
+  private authProvider: MsalAuthProvider;
 
   constructor(config: Configuration, authParams: AuthenticationParameters, type: LoginType = LoginType.Redirect) {
     this.config = config;
     this.authParameters = authParams;
     this.type = type;
+
+    if (this.type === LoginType.Popup) {
+      this.authProvider = new MsalPopupAuthProvider(this.config, this.authParameters);
+    } else {
+      this.authProvider = new MsalRedirectAuthProvider(this.config, this.authParameters);
+    }
   }
 
-  public getAuthProvider(): IAuthProvider {
-    if (this.type === LoginType.Popup) {
-      return new MsalPopupAuthProvider(this.config, this.authParameters);
-    } else {
-      return new MsalRedirectAuthProvider(this.config, this.authParameters);
-    }
+  public getAuthProvider(): MsalAuthProvider {
+    return this.authProvider;
   }
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -28,10 +28,11 @@ import { Account, AuthenticationParameters, AuthResponse, CacheLocation, Configu
 import { AAD_LOGIN_SUCCESS, AAD_LOGOUT_SUCCESS } from './actions';
 import { AzureAD } from './AzureAD'
 import { AuthenticationState, IAccountInfo, IAuthProviderFactory, LoginType } from './Interfaces';
+import { MsalAuthProvider } from './MsalAuthProvider';
 import { MsalAuthProviderFactory } from './MsalAuthProviderFactory';
 import { withAuthentication } from './withAuthentication';
 
 export { Account, AuthenticationParameters, AuthResponse, CacheLocation, Configuration, UserAgentApplication };
-export { AzureAD, AAD_LOGIN_SUCCESS, AAD_LOGOUT_SUCCESS, AuthenticationState, IAccountInfo, IAuthProviderFactory, LoginType, MsalAuthProviderFactory, withAuthentication };
+export { AzureAD, AAD_LOGIN_SUCCESS, AAD_LOGOUT_SUCCESS, AuthenticationState, IAccountInfo, IAuthProviderFactory, LoginType, MsalAuthProviderFactory, MsalAuthProvider, withAuthentication };
 
 export default AzureAD;


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
For advanced usage of the library, the `UserAgentApplication` needs to be exposed through the `MsalAuthProvider` base class as a means of accessing the underlying MSAL settings. However, the factory was returning the instantiated `MsalAuthProvider` instance as an `IAuthProvider` which does not have the `UserAgentApplication` property defined.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```