### PR TITLE
Make MSAL a peer dependency so clients can choose which version to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ A library of components to easily integrate the Microsoft Authentication Library
 Via NPM:
 
 ```
-npm install react-aad-msal
+npm install react-aad-msal msal --save
 ```
 
 ### Creating the Provider

--- a/package-lock.json
+++ b/package-lock.json
@@ -5510,6 +5510,7 @@
       "version": "1.2.0-beta.4",
       "resolved": "https://registry.npmjs.org/msal/-/msal-1.2.0-beta.4.tgz",
       "integrity": "sha512-1ANamflKfqQQ7GwgbJKuk7PSoTHCNFge78oexWQLdFkZ2L0mX2k4NEorPZVdR8PqPo1HnbnMyfbJ3pXVoG/F9g==",
+      "dev": true,
       "requires": {
         "tslib": "^1.9.3"
       }
@@ -7253,7 +7254,8 @@
     "tslib": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
+      "dev": true
     },
     "tslint": {
       "version": "5.19.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "version": "auto-changelog -p && git add CHANGELOG.md"
   },
   "dependencies": {
-    "msal": "1.2.0-beta.4",
     "redux": "4.0.4"
   },
   "devDependencies": {
@@ -65,10 +64,12 @@
     "tslint-config-prettier": "1.18.0",
     "tslint-microsoft-contrib": "6.2.0",
     "tslint-react": "4.0.0",
-    "typescript": "3.5.3"
+    "typescript": "3.5.3",
+    "msal": "1.2.0-beta.4"
   },
   "peerDependencies": {
-    "react": ">=16.8.0"
+    "react": ">=16.8.0",
+    "msal": ">=1.1.3"
   },
   "engines": {
     "node": ">= 8.10.0",

--- a/sample/package-lock.json
+++ b/sample/package-lock.json
@@ -5854,9 +5854,9 @@
       "integrity": "sha512-d4sze1JNC454Wdo2fkuyzCr6aHcbL6PGGuFAz0Li/NcOm1tCHGnWDRmJP85dh9IhQErTc2svWFEX5xHIOo//kQ=="
     },
     "handlebars": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.2.tgz",
-      "integrity": "sha512-cIv17+GhL8pHHnRJzGu2wwcthL5sb8uDKBHvZ2Dtu5s1YNt0ljbzKbamnc+gr69y7bzwQiBdr5+hOpRd5pnOdg==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
+      "integrity": "sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==",
       "requires": {
         "neo-async": "^2.6.0",
         "optimist": "^0.6.1",
@@ -8402,6 +8402,14 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
+    "msal": {
+      "version": "1.2.0-beta.4",
+      "resolved": "https://registry.npmjs.org/msal/-/msal-1.2.0-beta.4.tgz",
+      "integrity": "sha512-1ANamflKfqQQ7GwgbJKuk7PSoTHCNFge78oexWQLdFkZ2L0mX2k4NEorPZVdR8PqPo1HnbnMyfbJ3pXVoG/F9g==",
+      "requires": {
+        "tslib": "^1.9.3"
+      }
+    },
     "multicast-dns": {
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.2.3.tgz",
@@ -10339,7 +10347,6 @@
     "react-aad-msal": {
       "version": "file:..",
       "requires": {
-        "msal": "1.2.0-beta.2",
         "redux": "4.0.4"
       }
     },

--- a/sample/package.json
+++ b/sample/package.json
@@ -25,7 +25,8 @@
     "react-aad-msal": "file:../",
     "react-redux": "7.1.0",
     "react-scripts": "3.2.0",
-    "redux": "4.0.4"
+    "redux": "4.0.4",
+    "msal": "1.2.0-beta.4"
   },
   "devDependencies": {
     "rimraf": "3.0.0"


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
Today, MSAL is listed as a dependency in our library. This prevents consumers from selecting which version is right for them. This has a number of drawbacks:

1. Every time a new MSAL release occurs, we need to push out an update.
2. Consumers are forced to use a specific version of our library which might include other breaking changes when all they really wanted was to use a specific version of MSAL. This is especially pertinent this month, as MSAL has had numerous beta releases that people are eager to try out.
3. The final obvious drawback is that code could be bundled twice, or our library might not export a required class or interface from MSAL.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[x] Yes
[ ] No
```
Consumers will be prompted to install MSAL as a peer dependency if it is not already listed as a dependency in their package.json.


## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```
