### PR TITLE
Prevent forceLogin if there was an error

### DIFF
--- a/src/AzureAD.tsx
+++ b/src/AzureAD.tsx
@@ -68,7 +68,7 @@ export const AzureAD: React.FunctionComponent<IAzureADProps> = props => {
       provider.registerReduxStore(props.reduxStore);
     }
 
-    if (authenticationState === AuthenticationState.Unauthenticated && forceLogin) {
+    if (forceLogin && authenticationState === AuthenticationState.Unauthenticated && !error) {
       login();
     }
 


### PR DESCRIPTION
##  Purpose
There is an issue where when `forceLogin` is true and an error is encountered during the first login attempt, the error will be ignored and another attempt to login will occur. This creates edge cases where infinite loops happen, or a second error masks the root problem.

Instead, if an error is encountered login should not reprocess until a call to the `login()` function is called explicitly. This provides the consumer with a chance to intercept and handle the error before initiating a new login.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## Other Information
This could surface issues where some consumers code was encountering an error but it was previously being ignored and the second attempt was successful, often represented in a double login issue. Now, rather than a second login being initiated the developer will need to handle the error gracefully.