### PR TITLE
Add a new authentication state, InProgress

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ const config = {
   auth: {
     authority: 'https://login.microsoftonline.com/common',
     clientId: '<YOUR APPLICATION ID>',
-    redirectUri: '<OPTIONAL REDIRECT URI'
+    redirectUri: '<OPTIONAL REDIRECT URI>'
   },
   cache: {
     cacheLocation: "localStorage",
@@ -212,7 +212,7 @@ The `AzureAD` component is the primary method to add authentication to your appl
 The `AzureAD` component will check that the IdToken is not expired before determining that the user is authenticated. If the token has expired, it will attempt to renew it silently. If a valid token is maintained it will be sure there is an active Access Token available, otherwise it will refresh silently. If either of the tokens cannot be refreshed without user interaction, the user will be prompted to signin again.
 
 ```tsx
-import { AzureAD, AuthenticationState } from 'react-aad-msal';
+import { AzureAD, AuthenticationState, AuthenticationState } from 'react-aad-msal';
 
 // Import the provider created in a different file
 import { authProvider } from './authProvider';
@@ -231,29 +231,26 @@ import { authProvider } from './authProvider';
 <AzureAD provider={authProvider} forceLogin={true}>
   {
     ({login, logout, authenticationState, error, accountInfo}) => {
-      if (authenticationState === AuthenticationState.Authenticated) {
-        return (
-          <p>
-            <span>Welcome, {accountInfo.account.name}!</span>
-            <button onClick={logout}>Logout</button>
-          </p>
-        );
-      } else if (authenticationState === AuthenticationState.Unauthenticated) {
-        if (error) {
+      switch (authenticationState) {
+        case AuthenticationState.Authenticated:
           return (
+            <p>
+              <span>Welcome, {accountInfo.account.name}!</span>
+              <button onClick={logout}>Logout</button>
+            </p>
+          );
+        case AuthenticationState.Unauthenticated:
+          return (
+            <div>
+              {error && <p><span>An error occured during authentication, please try again!</span></p>}
               <p>
-                <span>An error occured during authentication, please try again!</span>
+                <span>Hey stranger, you look new!</span>
                 <button onClick={login}>Login</button>
               </p>
-            );
-        }
-
-        return (
-          <p>
-            <span>Hey stranger, you look new!</span>
-            <button onClick={login}>Login</button>
-          </p>
-        );
+            </div>
+          );
+        case AuthenticationState.InProgress:
+          return (<p>Authenticating...</p>);
       }
     }
   }
@@ -450,6 +447,8 @@ The project can be built with the following steps:
    - `npm run build`
 4. Run the sample project:
    - `npm start`
+
+Be sure to modify the [authProvider.js](sample/authProvider.js) configuration to specify your own `ClientID` and `Authority`.
 
 ## :calendar: Roadmap
 

--- a/sample/src/App.css
+++ b/sample/src/App.css
@@ -69,3 +69,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
   font-size: 15px;
   cursor: pointer;
 }
+
+.Button:disabled {
+  background-color: grey;
+}

--- a/sample/src/SampleAppButtonLaunch.js
+++ b/sample/src/SampleAppButtonLaunch.js
@@ -44,7 +44,11 @@ class SampleAppButtonLaunch extends React.Component {
     return (
       <AzureAD provider={authProvider} reduxStore={basicReduxStore}>
         {({ login, logout, authenticationState }) => {
-          if (authenticationState === AuthenticationState.Authenticated) {
+          const isInProgress = authenticationState === AuthenticationState.InProgress;
+          const isAuthenticated = authenticationState === AuthenticationState.Authenticated;
+          const isUnauthenticated = authenticationState === AuthenticationState.Unauthenticated;
+
+          if (isAuthenticated) {
             return (
               <React.Fragment>
                 <p>You're logged in!</p>
@@ -55,9 +59,9 @@ class SampleAppButtonLaunch extends React.Component {
                 <GetIdTokenButton provider={authProvider} />
               </React.Fragment>
             );
-          } else if (authenticationState === AuthenticationState.Unauthenticated) {
+          } else if (isUnauthenticated || isInProgress) {
             return (
-              <button className="Button" onClick={login}>
+              <button className="Button" onClick={login} disabled={isInProgress}>
                 Login
               </button>
             );

--- a/sample/src/SampleAppRedirectOnLaunch.js
+++ b/sample/src/SampleAppRedirectOnLaunch.js
@@ -91,7 +91,11 @@ class SampleAppRedirectOnLaunch extends React.Component {
     return (
       <AzureAD provider={authProvider} reduxStore={basicReduxStore}>
         {({ login, logout, authenticationState }) => {
-          if (authenticationState === AuthenticationState.Authenticated) {
+          const isInProgress = authenticationState === AuthenticationState.InProgress;
+          const isAuthenticated = authenticationState === AuthenticationState.Authenticated;
+          const isUnauthenticated = authenticationState === AuthenticationState.Unauthenticated;
+
+          if (isAuthenticated) {
             return (
               <React.Fragment>
                 <p>You're logged in!</p>
@@ -102,7 +106,7 @@ class SampleAppRedirectOnLaunch extends React.Component {
                 <GetIdTokenButton provider={authProvider} />
               </React.Fragment>
             );
-          } else if (authenticationState === AuthenticationState.Unauthenticated) {
+          } else if (isUnauthenticated || isInProgress) {
             this.countdownToLogin(login);
             return (
               <div>

--- a/src/AzureAD.tsx
+++ b/src/AzureAD.tsx
@@ -78,7 +78,7 @@ export const AzureAD: React.FunctionComponent<IAzureADProps> = props => {
       provider.unregisterAccountInfoHandler(onAccountInfoChanged);
       provider.unregisterErrorHandler(setError);
     };
-  }, []);
+  }, [authenticationState, accountInfo, error]);
 
   const login = useCallback(() => {
     provider.login();
@@ -184,6 +184,8 @@ export const AzureAD: React.FunctionComponent<IAzureADProps> = props => {
       //  Otherwise the content should be restricted until authenticated
       const functionOrChildren = getChildrenOrFunction(props.children, childrenFunctionProps);
       return functionOrChildren === props.children ? null : functionOrChildren;
+    case AuthenticationState.InProgress:
+      return getChildrenOrFunction(props.children, childrenFunctionProps);
     default:
       return null;
   }

--- a/src/Interfaces.ts
+++ b/src/Interfaces.ts
@@ -33,6 +33,7 @@ export enum LoginType {
 
 export enum AuthenticationState {
   Unauthenticated = 'Unauthenticated',
+  InProgress = 'InProgress',
   Authenticated = 'Authenticated',
 }
 

--- a/src/MsalAuthProvider.ts
+++ b/src/MsalAuthProvider.ts
@@ -82,10 +82,12 @@ export class MsalAuthProvider extends UserAgentApplication implements IAuthProvi
     this.setError(null);
 
     if (this._loginType === LoginType.Redirect) {
+      this.setAuthenticationState(AuthenticationState.InProgress);
       this.loginRedirect(this._parameters);
       // Nothing to do here, user will be redirected to the login page
     } else if (this._loginType === LoginType.Popup) {
       try {
+        this.setAuthenticationState(AuthenticationState.InProgress);
         await this.loginPopup(params);
       } catch (error) {
         Logger.ERROR(error);
@@ -290,6 +292,8 @@ export class MsalAuthProvider extends UserAgentApplication implements IAuthProvi
 
         this.setAuthenticationState(AuthenticationState.Unauthenticated);
       }
+    } else if (this.getLoginInProgress()) {
+      this.setAuthenticationState(AuthenticationState.InProgress);
     } else {
       this.setAuthenticationState(AuthenticationState.Unauthenticated);
     }


### PR DESCRIPTION
## Purpose
At the moment there are only two authentication states defined on the `AuthenticationState` enum, `Authenticated` and `Unauthenticated`. This kept things simple, but it loses some information because `msal` also has an in-progress state which represents when the user is currently in the process of logging in. Without exposing such a state, consumers of the library need to get creative with how to determine the in-progress state, and for example, show a progress indicator.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[x] Yes
[ ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```

## Other Information
This will possibly cause breaking changes for some consumers. Anyone using the Function as a Component pattern will need to account for this new state otherwise their function may not return any value, causing React to throw errors to the console.

The documentation has been updated to show the correct usage.