### PR TITLE
Update to MSAL version 1.2.0 and fix breaking changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ A library of components to easily integrate the Microsoft Authentication Library
     - [Creating the Provider](#creating-the-provider)
       - [Configuration Options](#configuration-options)
       - [Authentication Parameters](#authentication-parameters)
-      - [Login Type](#login-type)
+      - [Options](#options)
   - [:package: Authentication Components](#package-authentication-components)
     - [AzureAD Component](#azuread-component)
     - [Higher Order Component](#higher-order-component)
@@ -73,7 +73,7 @@ Before beginning it is required to configure an instance of the `MsalAuthProvide
 | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `config`     | Instance of a `Msal.Configuration` object to configure the underlying provider. The documentation for all the options can be found in the [configuration options](https://docs.microsoft.com/en-us/azure/active-directory/develop/msal-js-initializing-client-applications#configuration-options) doc         |
 | `parameters` | Instance of the `Msal.AuthenticationParameters` configuration to identify how the authentication process should function. This object includes the `scopes` values. You can see possible [values for scopes here](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-v2-scopes) |
-| `loginType`  | **[Optional]** A `LoginType` value which identifies whether the login operation is executed using a Popup or Reidrect. The default value is Popup                                                                                                                                                             |
+| `options`  | **[Optional]** The `options` are defined by the [IMsalAuthProviderConfig](src/Interfaces.ts) interface. This contains settings that describe how the authentication provider should handle certain authentication processes.                                                                                                                                                             |
 
 The `MsalAuthProvider` is meant to be a singleton. There are known implications when multiple instances of MSAL are running at the same time. The recommended approach is to instantiate the `MsalAuthProvider` in a separate file and `import` it when needed.
 
@@ -100,7 +100,12 @@ const authenticationParameters = {
   ]
 }
 
-export const authProvider = new MsalAuthProvider(config, authenticationParameters, LoginType.Popup)
+const options = {
+  loginType: LoginType.Popup,
+  tokenRefreshUri: window.location.origin + '/auth.html'
+}
+
+export const authProvider = new MsalAuthProvider(config, authenticationParameters, options)
 ```
 
 Now you can `import` the `authProvider` and use it in combination with one of the authentication components.
@@ -185,9 +190,24 @@ The set of options that are supported for the `Msal.AuthenticationParameters` cl
   };
 ```
 
-#### Login Type
+#### Options
 
-The `LoginType` parameter is an enum with two options for `Popup` or `Redirect` authentication. This parameter is optional and will default to `Popup` if not provided. At any time after instantiating the `MsalAuthProvider` the login type can be changed using the `setLoginType()` method.
+The `options` parameter defines settings related to how the authentication provider processes authentication operations.
+
+```typescript
+const options = {
+  // The default login type is Popup
+  loginType: LoginType.Popup,
+  // A blank html page that MSAL can load in an iframe to refresh the token
+  // The default setting for this parameter is `window.location.origin`
+  tokenRefreshUri: window.location.origin + '/auth.html'
+}
+```
+
+ `LoginType` is an enum with two options for `Popup` or `Redirect` authentication. This parameter is optional and will default to `Popup` if not provided. The `tokenRefreshUri` allows you to set a separate page to load only when tokens are being refreshed. When `MSAL` attempts to refresh a token, it will reload the page in an iframe. This option allows you to inform `MSAL` of a specific page it can load in the iframe. It is best practice to use a blank HTML file so as to prevent all your site scripts and contents from loading multiple times.
+ 
+
+ At any time after instantiating the `MsalAuthProvider` the login type can be changed using the `setProviderOptions()` method. You may also retrieve the current options using the `getProviderOptions()` method.
 
 ## :package: Authentication Components
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-aad-msal",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5507,9 +5507,9 @@
       "dev": true
     },
     "msal": {
-      "version": "1.2.0-beta.4",
-      "resolved": "https://registry.npmjs.org/msal/-/msal-1.2.0-beta.4.tgz",
-      "integrity": "sha512-1ANamflKfqQQ7GwgbJKuk7PSoTHCNFge78oexWQLdFkZ2L0mX2k4NEorPZVdR8PqPo1HnbnMyfbJ3pXVoG/F9g==",
+      "version": "1.2.0-beta.5",
+      "resolved": "https://registry.npmjs.org/msal/-/msal-1.2.0-beta.5.tgz",
+      "integrity": "sha512-1Dq5Bu73em6w3Qfrmqjad+D414T86EqGErFtGKBvzrinYIMd+S7zrhVbSPAJ/F3yRnnt1sAE2EOFIgCp08x71A==",
       "dev": true,
       "requires": {
         "tslib": "^1.9.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-aad-msal",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "A react component that integrates with Azure AD (v2, MSAL).",
   "private": false,
   "license": "MIT",
@@ -65,11 +65,11 @@
     "tslint-microsoft-contrib": "6.2.0",
     "tslint-react": "4.0.0",
     "typescript": "3.5.3",
-    "msal": "1.2.0-beta.4"
+    "msal": "1.2.0"
   },
   "peerDependencies": {
     "react": ">=16.8.0",
-    "msal": ">=1.1.3"
+    "msal": ">=1.2.0"
   },
   "engines": {
     "node": ">= 8.10.0",

--- a/package.json
+++ b/package.json
@@ -65,11 +65,11 @@
     "tslint-microsoft-contrib": "6.2.0",
     "tslint-react": "4.0.0",
     "typescript": "3.5.3",
-    "msal": "1.2.0"
+    "msal": "1.2.0-beta.5"
   },
   "peerDependencies": {
     "react": ">=16.8.0",
-    "msal": ">=1.2.0"
+    "msal": ">1.1.3"
   },
   "engines": {
     "node": ">= 8.10.0",

--- a/sample/package-lock.json
+++ b/sample/package-lock.json
@@ -8403,9 +8403,9 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "msal": {
-      "version": "1.2.0-beta.4",
-      "resolved": "https://registry.npmjs.org/msal/-/msal-1.2.0-beta.4.tgz",
-      "integrity": "sha512-1ANamflKfqQQ7GwgbJKuk7PSoTHCNFge78oexWQLdFkZ2L0mX2k4NEorPZVdR8PqPo1HnbnMyfbJ3pXVoG/F9g==",
+      "version": "1.2.0-beta.5",
+      "resolved": "https://registry.npmjs.org/msal/-/msal-1.2.0-beta.5.tgz",
+      "integrity": "sha512-1Dq5Bu73em6w3Qfrmqjad+D414T86EqGErFtGKBvzrinYIMd+S7zrhVbSPAJ/F3yRnnt1sAE2EOFIgCp08x71A==",
       "requires": {
         "tslib": "^1.9.3"
       }

--- a/sample/package.json
+++ b/sample/package.json
@@ -26,7 +26,7 @@
     "react-redux": "7.1.0",
     "react-scripts": "3.2.0",
     "redux": "4.0.4",
-    "msal": "1.2.0"
+    "msal": "1.2.0-beta.5"
   },
   "devDependencies": {
     "rimraf": "3.0.0"

--- a/sample/package.json
+++ b/sample/package.json
@@ -26,7 +26,7 @@
     "react-redux": "7.1.0",
     "react-scripts": "3.2.0",
     "redux": "4.0.4",
-    "msal": "1.2.0-beta.4"
+    "msal": "1.2.0"
   },
   "devDependencies": {
     "rimraf": "3.0.0"

--- a/sample/public/auth.html
+++ b/sample/public/auth.html
@@ -1,0 +1,11 @@
+<!--
+  A blank html helper file for authentication redirects.
+
+  If using the popup authentication method, point the redirectUrl to this file for a more performant authentication.
+  Rather than the authentication popup loading the entire page in an iframe and downloading scripts/css twice,
+  the MSAL library will use this blank HTML file as a valid route on the domain to store items in cache and deal
+  with cookies.
+
+  If not using the popup authentication method, this file can still be used for refresh tokens, where the file will be loaded
+  in the refresh iframe rather than reloading your entire site.
+-->

--- a/sample/src/SampleAppButtonLaunch.js
+++ b/sample/src/SampleAppButtonLaunch.js
@@ -37,7 +37,9 @@ class SampleAppButtonLaunch extends React.Component {
     super(props);
 
     // Change the login type to execute in a Popup
-    authProvider.setLoginType(LoginType.Popup);
+    const options = authProvider.getProviderOptions();
+    options.loginType = LoginType.Popup;
+    authProvider.setProviderOptions(options);
   }
 
   render() {

--- a/sample/src/SampleAppRedirectOnLaunch.js
+++ b/sample/src/SampleAppRedirectOnLaunch.js
@@ -38,7 +38,9 @@ class SampleAppRedirectOnLaunch extends React.Component {
     super(props);
 
     // Change the login type to execute in a Redirect
-    authProvider.setLoginType(LoginType.Redirect);
+    const options = authProvider.getProviderOptions();
+    options.loginType = LoginType.Redirect;
+    authProvider.setProviderOptions(options);
 
     this.interval = null;
     let redirectEnabled = sessionStorage.getItem('redirectEnabled') || false;

--- a/sample/src/authProvider.js
+++ b/sample/src/authProvider.js
@@ -49,5 +49,11 @@ export const authProvider = new MsalAuthProvider(
   {
     scopes: ['openid'],
   },
-  LoginType.Popup,
+  {
+    loginType: LoginType.Popup,
+    // When a token is refreshed it will be done by loading a page in an iframe.
+    // Rather than reloading the same page, we can point to an empty html file which will prevent
+    // site resources from being loaded twice.
+    tokenRefreshUri: window.location.origin + '/auth.html',
+  },
 );

--- a/src/Interfaces.ts
+++ b/src/Interfaces.ts
@@ -56,3 +56,13 @@ export interface IAuthProvider {
   login(): void;
   logout(): void;
 }
+
+export interface IMsalAuthProviderConfig {
+  // Determines whether the login process is executed in a new popup window,
+  // or by redirecting to the login page
+  loginType: LoginType;
+  // When a token is refreshed it will be done by loading a page in an iframe.
+  // Rather than reloading the same page, we can point to an empty html file which will prevent
+  // site resources from being loaded twice.
+  tokenRefreshUri?: string;
+}


### PR DESCRIPTION
## Purpose
The MSAL library has been updated to version 1.2.0. This new release has a number of fixes and useful improvements. This PR updates to the latest version and implements fixes for breaking changes.

**Breaking Changes**

1. New `MsalAuthProvider` options parameter
The API has changed so that when instantiating an instance of `MsalAuthProvider` the third parameter is no longer the `LoginType`. Instead, it takes an options object which allows you to set the `loginType` and a new `refreshTokenUri` to specify a path (or html file) to be loaded when the library attempts to refresh an Id Token or Access Token. Before this improvement when the refresh process would occur in an iframe, the whole site would generally reload. This would cause many of your site resources to be loaded twice. Instead, we can now reference a blank html file that can be loaded in the iframe so that no additional resources are necessary.

2. Retired the `MsalAuthProvider.setLoginType()` method
Instead, you should use the `getProviderOptions()` and `setProviderOptions()` methods to change the provider settings.

The sample and documentation have been updated to reflect these changes.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[x] Yes
[ ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```