### PR TITLE
Removing domain_hint parameter for silent token calls

### DIFF
--- a/packages/react-aad-msal/src/MsalAuthProvider.ts
+++ b/packages/react-aad-msal/src/MsalAuthProvider.ts
@@ -116,6 +116,16 @@ export class MsalAuthProvider extends UserAgentApplication implements IAuthProvi
       redirectUri: (parameters && parameters.redirectUri) || providerOptions.tokenRefreshUri,
     };
 
+    /* In this library, acquireTokenSilent is being called only when there is an accountInfo of an expired session.
+        *  In a scenario where user interaction is required, username from the account info is passed as 'login_hint'
+        *  parameter which redirects user to user's organization login page. So 'domain_hint' is not required to be
+        *  passed for silent calls. Hence, the below code is to avoid sending domain_hint. This also solves the issue
+        *  of multiple domain_hint param being added by the MSAL.js.
+    */
+    if (refreshParams.extraQueryParameters && refreshParams.extraQueryParameters.domain_hint) {
+      delete refreshParams.extraQueryParameters.domain_hint;
+    }
+
     try {
       const response = await this.acquireTokenSilent(refreshParams);
 
@@ -149,6 +159,16 @@ export class MsalAuthProvider extends UserAgentApplication implements IAuthProvi
       // Pass the clientId as the only scope to get a renewed IdToken if it has expired
       scopes: [clientId],
     };
+
+    /* In this library, acquireTokenSilent is being called only when there is an accountInfo of an expired session.
+        *  In a scenario where user interaction is required, username from the account info is passed as 'login_hint'
+        *  parameter which redirects user to user's organization login page. So 'domain_hint' is not required to be
+        *  passed for silent calls. Hence, the below code is to avoid sending domain_hint. This also solves the issue
+        *  of multiple domain_hint param being added by the MSAL.js.
+    */
+    if (refreshParams.extraQueryParameters && refreshParams.extraQueryParameters.domain_hint) {
+      delete refreshParams.extraQueryParameters.domain_hint;
+    }
 
     try {
       const response = await this.acquireTokenSilent(refreshParams);


### PR DESCRIPTION
Removing domain_hint parameter from silent calls as it is not required when executing acquire token silent

## Purpose
Removing **domain_hint** auth param **only for silent token calls**
* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [remove-domain-hint]
yarn install
yarn build
Configure your azure config along with domain hint in the react-typescript-sample
Run the app
Login
wait for your session to expire
hit the url again
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
The last step above will show a blank page with script error. With this fix it should redirect you to login page 
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->