### PR TITLE
Started getting TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string

### DIFF
--- a/samples/react-javascript/package.json
+++ b/samples/react-javascript/package.json
@@ -30,7 +30,7 @@
     "react-aad-msal": "^2.3.2",
     "react-dom": "^16.12.0",
     "react-redux": "^7.1.3",
-    "react-scripts": "3.3.0",
+    "react-scripts": "3.4.0",
     "redux": "^4.0.5"
   },
   "devDependencies": {


### PR DESCRIPTION
## Purpose
Started getting TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string
* same issue as https://github.com/facebook/create-react-app/issues/8499

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone https://github.com/Rahulkishanm/react-aad
cd samples
cd react-javascript
npm install
npm start
```

## What to Check
Earlier without an upgrade, of react script we were having the issue mentioned above.
Now after an upgrade of react script, we solved this issue
